### PR TITLE
Support Multiple Pages in PDFs

### DIFF
--- a/demo/js/main.js
+++ b/demo/js/main.js
@@ -2,7 +2,7 @@ import formatDistanceToNow from 'date-fns/formatDistanceToNow';
 import parse from 'date-fns/parse';
 import { de } from 'date-fns/locale';
 
-import { extractActivity } from '../../src';
+import { extractActivities } from '../../src';
 
 new Vue({
   el: '#app',
@@ -51,22 +51,25 @@ new Vue({
       files.map(this.createActivityFromPDF);
     },
     async createActivityFromPDF(file) {
-      let activity;
+      let activities;
       var fileReader = new FileReader();
       fileReader.onload = async e => {
-        activity = await extractActivity(e);
+        activities = await extractActivities(e);
 
-        const a = {
-          ...activity,
-          filename: file.name,
-          parsed: true,
-        };
+        activities.map((activity) => {
+          const a = {
+            ...activity,
+            filename: file.name,
+            parsed: true,
+          };
 
-        console.log(a);
-        this.activities.push(a);
+          console.log(a);
+          this.activities.push(a);
+        })
+
       };
       fileReader.readAsArrayBuffer(file);
-      return activity;
+      return activities;
     },
   },
 });

--- a/demo/js/main.js
+++ b/demo/js/main.js
@@ -56,7 +56,7 @@ new Vue({
       fileReader.onload = async e => {
         activities = await extractActivities(e);
 
-        activities.map((activity) => {
+        activities.map(activity => {
           const a = {
             ...activity,
             filename: file.name,
@@ -65,8 +65,7 @@ new Vue({
 
           console.log(a);
           this.activities.push(a);
-        })
-
+        });
       };
       fileReader.readAsArrayBuffer(file);
       return activities;

--- a/src/brokers/comdirect.js
+++ b/src/brokers/comdirect.js
@@ -145,7 +145,7 @@ export const parseData = textArr => {
 };
 
 export const parsePages = contents => {
-  // parse first page
+  // only first page has activity data
   const activity = parseData(contents[0]);
   return [activity];
 };

--- a/src/brokers/comdirect.js
+++ b/src/brokers/comdirect.js
@@ -16,7 +16,10 @@ const findISIN = (text, span) => {
 const findCompany = (text, span) => {
   const companyLine = text[text.findIndex(t => t.includes('/ISIN')) + span];
   // span = 2 means its a dividend PDF - dividends dont have the WKN in the same line
-  const company = span === 2 ? companyLine.trim() : companyLine.substr(0, companyLine.length - 6).trim();
+  const company =
+    span === 2
+      ? companyLine.trim()
+      : companyLine.substr(0, companyLine.length - 6).trim();
 
   return company;
 };
@@ -143,6 +146,6 @@ export const parseData = textArr => {
 
 export const parsePages = contents => {
   // parse first page
-  const activity = parseData(contents[0])
+  const activity = parseData(contents[0]);
   return [activity];
-}
+};

--- a/src/brokers/comdirect.js
+++ b/src/brokers/comdirect.js
@@ -140,3 +140,9 @@ export const parseData = textArr => {
     return activity;
   }
 };
+
+export const parsePages = contents => {
+  // parse first page
+  const activity = parseData(contents[0])
+  return [activity];
+}

--- a/src/brokers/dkb.js
+++ b/src/brokers/dkb.js
@@ -129,7 +129,7 @@ export const parseData = textArr => {
 };
 
 export const parsePages = contents => {
-  // parse first page
+  // parse first page has activity data
   const activity = parseData(contents[0]);
   return [activity];
 };

--- a/src/brokers/dkb.js
+++ b/src/brokers/dkb.js
@@ -130,6 +130,6 @@ export const parseData = textArr => {
 
 export const parsePages = contents => {
   // parse first page
-  const activity = parseData(contents[0])
+  const activity = parseData(contents[0]);
   return [activity];
-}
+};

--- a/src/brokers/dkb.js
+++ b/src/brokers/dkb.js
@@ -127,3 +127,9 @@ export const parseData = textArr => {
     return activity;
   }
 };
+
+export const parsePages = contents => {
+  // parse first page
+  const activity = parseData(contents[0])
+  return [activity];
+}

--- a/src/brokers/traderepublic.js
+++ b/src/brokers/traderepublic.js
@@ -195,3 +195,9 @@ export const parseData = textArr => {
     return activity;
   }
 };
+
+export const parsePages = contents => {
+  // parse first page
+  const activity = parseData(contents[0])
+  return [activity];
+}

--- a/src/brokers/traderepublic.js
+++ b/src/brokers/traderepublic.js
@@ -197,7 +197,7 @@ export const parseData = textArr => {
 };
 
 export const parsePages = contents => {
-  // parse first page
+  // trade republic only has one-page PDFs
   const activity = parseData(contents[0]);
   return [activity];
 };

--- a/src/brokers/traderepublic.js
+++ b/src/brokers/traderepublic.js
@@ -198,6 +198,6 @@ export const parseData = textArr => {
 
 export const parsePages = contents => {
   // parse first page
-  const activity = parseData(contents[0])
+  const activity = parseData(contents[0]);
   return [activity];
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export const getBroker = textArr => {
   return supportedBrokers[0];
 };
 
-const parsePage = async (page) => {
+const parsePage = async page => {
   let textArr;
 
   const tc = await page.getTextContent();
@@ -37,13 +37,13 @@ const parsePage = async (page) => {
   }
   textArr = out.filter(i => i.length > 0);
 
-  return textArr
-}
+  return textArr;
+};
 
 export const extractActivities = async e => {
   const result = new Uint8Array(e.currentTarget.result);
   const pdf = await pdfjs.getDocument(result).promise;
-  console.log('Pages', pdf.numPages)
+  console.log('Pages', pdf.numPages);
 
   // get contents of all pages as array of textArrays
   const contents = [];
@@ -51,9 +51,9 @@ export const extractActivities = async e => {
 
   for (const [i] of loopHelper) {
     const pageNum = i + 1;
-    const page = await pdf.getPage(pageNum)
-    const textArr = await parsePage(page)
-    contents.push(textArr)
+    const page = await pdf.getPage(pageNum);
+    const textArr = await parsePage(page);
+    contents.push(textArr);
   }
 
   let activities = [];

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,10 @@ import * as brokers from './brokers';
 pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorker;
 
 const getActivity = contents => {
+  // identify broker from first page
   const broker = getBroker(contents[0]);
 
+  // get activities from all pages
   return broker.parsePages(contents);
 };
 
@@ -27,6 +29,7 @@ export const getBroker = textArr => {
 };
 
 const parsePage = async page => {
+  // extract content of page as an array of strings
   let textArr;
 
   const tc = await page.getTextContent();
@@ -43,7 +46,6 @@ const parsePage = async page => {
 export const extractActivities = async e => {
   const result = new Uint8Array(e.currentTarget.result);
   const pdf = await pdfjs.getDocument(result).promise;
-  console.log('Pages', pdf.numPages);
 
   // get contents of all pages as array of textArrays
   const contents = [];
@@ -56,6 +58,7 @@ export const extractActivities = async e => {
     contents.push(textArr);
   }
 
+  // get activities out of entire PDF (all pages)
   let activities = [];
 
   try {


### PR DESCRIPTION
Adds support for multiple pages.
Broker files now return array of activities.
Current brokers just parse the first page.

Fixes #16 