### PR TITLE
Add activity validation for all existing brokers

### DIFF
--- a/src/brokers/consorsbank.js
+++ b/src/brokers/consorsbank.js
@@ -1,10 +1,8 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
 import Big from 'big.js';
 
-import { parseGermanNum } from '@/helper';
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const findISIN = text => text[text.findIndex(t => t === 'ISIN') + 3];
 
@@ -177,7 +175,7 @@ export const parseData = textArr => {
     tax = findDividendTax(textArr);
   }
 
-  const activity = {
+  return validateActivity({
     broker: 'consorsbank',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
@@ -188,16 +186,7 @@ export const parseData = textArr => {
     amount,
     fee,
     tax,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) {
-    console.error('Error while parsing PDF', activity);
-    return undefined;
-  } else {
-    return activity;
-  }
+  });
 };
 
 export const parsePages = contents => {

--- a/src/brokers/flatex.js
+++ b/src/brokers/flatex.js
@@ -1,10 +1,8 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
-import { Big } from 'big.js';
+import Big from 'big.js';
 
-import { parseGermanNum } from '@/helper';
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const getTableValueByKey = (textArr, startLineNumer, key) => {
   const finding = textArr.find(
@@ -220,12 +218,9 @@ export const parsePage = (textArr, startLineNumer) => {
     price = amount / shares;
     fee = 0;
     tax = findDividendTax(textArr, startLineNumer);
-  } else {
-    console.error('Type could not be determined!');
-    return undefined;
   }
 
-  const activity = {
+  return validateActivity({
     broker: 'flatex',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
@@ -236,16 +231,7 @@ export const parsePage = (textArr, startLineNumer) => {
     amount,
     fee,
     tax,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) {
-    console.error('Error while parsing PDF', activity);
-    return undefined;
-  } else {
-    return activity;
-  }
+  });
 };
 
 export const parsePages = contents => {

--- a/src/brokers/ing.js
+++ b/src/brokers/ing.js
@@ -1,10 +1,8 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
 import Big from 'big.js';
 
-import { parseGermanNum } from '@/helper';
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const getValueByPreviousElement = (textArr, prev, range) =>
   textArr[textArr.findIndex(t => t.includes(prev)) + range];
@@ -130,12 +128,9 @@ export const parseData = textArr => {
     price = +Big(amount).div(shares);
     fee = 0;
     tax = findTaxes(textArr);
-  } else {
-    console.error('Type could not be determined!');
-    return undefined;
   }
 
-  const activity = {
+  return validateActivity({
     broker: 'ing',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
@@ -146,16 +141,7 @@ export const parseData = textArr => {
     amount,
     fee,
     tax,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) {
-    console.error('Error while parsing PDF', activity);
-    return undefined;
-  } else {
-    return activity;
-  }
+  });
 };
 
 export const parsePages = contents => {

--- a/src/brokers/onvista.js
+++ b/src/brokers/onvista.js
@@ -1,10 +1,8 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
 import Big from 'big.js';
 
-import { parseGermanNum } from '@/helper';
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const findISIN = text => {
   const isin = text[text.findIndex(t => t.includes('ISIN')) + 1];
@@ -181,12 +179,12 @@ export const parseData = text => {
     tax = findTax(text);
     shares = findShares(text);
     price = +Big(amount).div(shares);
-  } else throw { text: 'Unknown document type' };
+  }
 
   isin = findISIN(text);
   company = findCompany(text);
 
-  const activity = {
+  return validateActivity({
     broker: 'onvista',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
@@ -197,12 +195,7 @@ export const parseData = text => {
     amount,
     fee,
     tax,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) throw { text: 'Error while parsing PDF', activity };
-  return activity;
+  });
 };
 
 export const parsePages = contents => {

--- a/src/brokers/pb.js
+++ b/src/brokers/pb.js
@@ -1,15 +1,13 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
+
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const offsets = {
   shares: 0,
   companyName: 1,
   isin: 3,
 };
-
-import { parseGermanNum } from '@/helper';
 
 const getValueByPreviousElement = (textArr, prev) =>
   textArr[textArr.findIndex(t => t.includes(prev)) + 1];
@@ -104,13 +102,10 @@ export const parseData = textArr => {
     amount = findPayout(textArr);
     price = amount / shares;
     fee = 0;
-  } else {
-    console.error('Type could not be determined!');
-    return undefined;
   }
 
-  const activity = {
-    broker: 'pb',
+  return validateActivity({
+    broker: 'postbank',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
     isin,
@@ -119,16 +114,7 @@ export const parseData = textArr => {
     price,
     amount,
     fee,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) {
-    console.error('Error while parsing PDF', activity);
-    return undefined;
-  } else {
-    return activity;
-  }
+  });
 };
 
 export const parsePages = contents => {

--- a/src/brokers/traderepublic.js
+++ b/src/brokers/traderepublic.js
@@ -1,10 +1,8 @@
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
-import every from 'lodash/every';
-import values from 'lodash/values';
 import Big from 'big.js';
 
-import { parseGermanNum } from '@/helper';
+import { parseGermanNum, validateActivity } from '@/helper';
 
 const findISIN = text => {
   if (text.some(t => t.includes('ISIN:'))) {
@@ -191,11 +189,9 @@ export const parseData = textArr => {
     price = +Big(amount).div(Big(shares));
     fee = findFee(textArr);
     tax = findTax(textArr);
-  } else {
-    console.error('unable to detect order');
   }
 
-  const activity = {
+  return validateActivity({
     broker: 'traderepublic',
     type,
     date: format(parse(date, 'dd.MM.yyyy', new Date()), 'yyyy-MM-dd'),
@@ -206,16 +202,7 @@ export const parseData = textArr => {
     amount,
     fee,
     tax,
-  };
-
-  const valid = every(values(activity), a => !!a || a === 0);
-
-  if (!valid) {
-    console.error('Error while parsing PDF', activity);
-    return undefined;
-  } else {
-    return activity;
-  }
+  });
 };
 
 export const parsePages = contents => {

--- a/src/helper/index.js
+++ b/src/helper/index.js
@@ -1,3 +1,6 @@
+import every from 'lodash/every';
+import values from 'lodash/values';
+
 export function csvJSON(csv) {
   var lines = csv.trim().split('\n');
 
@@ -29,4 +32,105 @@ export function parseGermanNum(n) {
     return 0;
   }
   return parseFloat(n.replace(/\./g, '').replace(',', '.'));
+}
+
+export function validateActivity(activity) {
+  // All fields must have a value unequal undefined
+  if (!every(values(activity), a => !!a || a === 0)) {
+    console.error(
+      'The activity for ' + activity.broker + ' has empty fields.',
+      activity
+    );
+    return undefined;
+  }
+
+  // The date must be in the past.
+  if (activity.date > new Date()) {
+    console.error(
+      'The activity for ' + activity.broker + ' has to be in the past.',
+      activity
+    );
+    return undefined;
+  }
+
+  // The date must be not older than 1990-01-01
+  if (activity.date < new Date(1990, 1, 1)) {
+    console.error(
+      'The activity for ' + activity.broker + ' is older than 1990-01-01.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (Number(activity.shares) !== activity.shares || activity.shares <= 0) {
+    console.error(
+      'The shares in activity for ' +
+        activity.broker +
+        ' must be a number greater than 0.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (Number(activity.price) !== activity.price || activity.price <= 0) {
+    console.error(
+      'The price in activity for ' +
+        activity.broker +
+        ' must be a number greater than 0.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (Number(activity.amount) !== activity.amount || activity.amount <= 0) {
+    console.error(
+      'The amount in activity for ' +
+        activity.broker +
+        ' must be a number greater than 0.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (Number(activity.fee) !== activity.fee || activity.fee < 0) {
+    console.error(
+      'The fee amount in activity for ' +
+        activity.broker +
+        ' must be a number greater than 0.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (Number(activity.tax) !== activity.tax || activity.tax < 0) {
+    console.error(
+      'The tax amount in activity for ' +
+        activity.broker +
+        ' must be a number greater than 0.',
+      activity
+    );
+    return undefined;
+  }
+
+  if (!/^([A-Z]{2})([A-Z0-9]{9})([0-9]{1})$/.test(activity.isin)) {
+    console.error(
+      'The activity ISIN for ' +
+        activity.broker +
+        " can't be valid with an invalid scheme.",
+      activity
+    );
+    return undefined;
+  }
+
+  if (!['Buy', 'Sell', 'Dividend'].includes(activity.type)) {
+    console.error(
+      'The activity type for ' +
+        activity.broker +
+        " can't be valid with an unknown type.",
+      activity
+    );
+    return undefined;
+  }
+
+  return activity;
 }

--- a/tests/brokers/comdirect.test.js
+++ b/tests/brokers/comdirect.test.js
@@ -38,6 +38,7 @@ describe('Broker: comdirect', () => {
         price: 44.74545454545454,
         amount: 24.61,
         fee: 0.37,
+        tax: 0,
       });
     });
 
@@ -55,6 +56,7 @@ describe('Broker: comdirect', () => {
         price: 235.09259259259258,
         amount: 24.84,
         fee: 0,
+        tax: 0,
       });
     });
   });
@@ -74,6 +76,7 @@ describe('Broker: comdirect', () => {
         price: 0.007280978021605879,
         amount: 0.43,
         fee: 0,
+        tax: 0,
       });
     });
 
@@ -91,6 +94,7 @@ describe('Broker: comdirect', () => {
         price: 0.9696831200487508,
         amount: 12.73,
         fee: 0,
+        tax: 0,
       });
     });
   });

--- a/tests/brokers/dkb.test.js
+++ b/tests/brokers/dkb.test.js
@@ -19,17 +19,21 @@ describe('DKB broker', () => {
     const activity = parseData(invalidSample);
 
     expect(activity).toEqual(undefined);
-    expect(console.error).toHaveBeenLastCalledWith('Error while parsing PDF', {
-      amount: 4428,
-      broker: 'dkb',
-      company: 'Kurswert',
-      date: '2019-01-25',
-      fee: 10,
-      isin: null,
-      price: 123,
-      shares: NaN,
-      type: 'Buy',
-    });
+    expect(console.error).toHaveBeenLastCalledWith(
+      'The activity for dkb has empty fields.',
+      {
+        amount: 4428,
+        broker: 'dkb',
+        company: 'Kurswert',
+        date: '2019-01-25',
+        fee: 10,
+        isin: null,
+        price: 123,
+        shares: NaN,
+        type: 'Buy',
+        tax: 0,
+      }
+    );
   });
 
   describe('Buy', () => {
@@ -46,6 +50,7 @@ describe('DKB broker', () => {
         price: 123,
         amount: 4428,
         fee: 10,
+        tax: 0,
       });
     });
 
@@ -62,8 +67,10 @@ describe('DKB broker', () => {
         price: 177.85,
         amount: 177.85,
         fee: 10,
+        tax: 0,
       });
     });
+
     test('should map pdf data of sample 3 correctly', () => {
       const activity = parseData(buySamples[2]);
 
@@ -77,6 +84,7 @@ describe('DKB broker', () => {
         price: 353.8346,
         amount: 262.5,
         fee: 1.5,
+        tax: 0,
       });
     });
   });
@@ -95,6 +103,7 @@ describe('DKB broker', () => {
         price: 123,
         amount: 4428,
         fee: 10,
+        tax: 0,
       });
     });
   });
@@ -113,8 +122,10 @@ describe('DKB broker', () => {
         price: 0.6019444444444445,
         amount: 21.67,
         fee: 0,
+        tax: 0,
       });
     });
+
     test('should map pdf data of sample 2 correctly', () => {
       const activity = parseData(dividendsSamples[1]);
 
@@ -128,6 +139,7 @@ describe('DKB broker', () => {
         price: 0.27799999999999997,
         amount: 1.39,
         fee: 0,
+        tax: 0,
       });
     });
     test('should map pdf data of sample 3 correctly', () => {
@@ -143,6 +155,7 @@ describe('DKB broker', () => {
         price: 0.375,
         amount: 4.5,
         fee: 0,
+        tax: 0,
       });
     });
   });

--- a/tests/helper/index.test.js
+++ b/tests/helper/index.test.js
@@ -1,0 +1,286 @@
+import * as helper from '../../src/helper';
+
+describe('Heler functions', () => {
+  let consoleErrorSpy;
+
+  describe('Function: validateActivity', () => {
+    test('Is a valid activity valid', () => {
+      const activity = {
+        broker: 'traderepublic',
+        type: 'Sell',
+        date: new Date(2000, 1, 1),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(activity).toEqual(helper.validateActivity(activity));
+    });
+
+    test('Activity without broker should be invalid', () => {
+      const activity = {
+        broker: undefined,
+        type: 'Sell',
+        date: new Date(2000, 1, 1),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The activity for undefined has empty fields.',
+        activity
+      );
+    });
+
+    test('Activity without type should be invalid', () => {
+      const activity = {
+        broker: 'traderepublic',
+        type: undefined,
+        date: new Date(2000, 1, 1),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The activity for traderepublic has empty fields.',
+        activity
+      );
+    });
+
+    test('Activity with a date newer than today should be invalid', () => {
+      var today = new Date();
+
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: today.setDate(today.getDate() + 1),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The activity for comdirect has to be in the past.',
+        activity
+      );
+    });
+
+    test('Activity with a date older than 1990-01-01 should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(1989, 12, 31),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The activity for comdirect is older than 1990-01-01.',
+        activity
+      );
+    });
+
+    test('Activity with a negative number of shares should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: -42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The shares in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with a string value as shares should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: '42',
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The shares in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with a negative price per shares should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: -42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The price in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with a string value as price per shares should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: '42',
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The price in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with a negative amount should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: -1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The amount in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with a string value as amount should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Sell',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: '1764',
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        'The amount in activity for comdirect must be a number greater than 0.',
+        activity
+      );
+    });
+
+    test('Activity with an unknown ISIN sheme should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'Dividend',
+        date: new Date(),
+        isin: 'DE123456789',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        "The activity ISIN for comdirect can't be valid with an invalid scheme.",
+        activity
+      );
+    });
+
+    test('Activity with an unknown type should be invalid', () => {
+      const activity = {
+        broker: 'comdirect',
+        type: 'WaynTrain',
+        date: new Date(),
+        isin: 'DETRESOR1042',
+        company: 'Tresor 1 Inc.',
+        shares: 42,
+        price: 42,
+        amount: 1764,
+        fee: 1,
+        tax: 0,
+      };
+
+      expect(helper.validateActivity(activity)).toEqual(undefined);
+      expect(console.error).toHaveBeenLastCalledWith(
+        "The activity type for comdirect can't be valid with an unknown type.",
+        activity
+      );
+    });
+  });
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,11 +1,14 @@
 import { getBroker } from '../src';
 
 describe('PDF bandler', () => {
+  let consoleErrorSpy;
+
   describe('getBroker', () => {
     test('should return the matching broker', () => {
       const broker = getBroker(['BIC BYLADEM1001', 'Dividendengutschrift']);
       expect(typeof broker.parseData).toEqual('function');
     });
+
     test('should throw when no matcher was found', () => {
       try {
         getBroker(['42']);
@@ -14,11 +17,20 @@ describe('PDF bandler', () => {
       }
     });
   });
+
   test('should throw when more than one matcher was found', () => {
     try {
       getBroker(['BIC BYLADEM1001', 'Dividendengutschrift', 'comdirect bank']);
     } catch (e) {
       expect(e).toEqual('Multiple supported brokers found!');
     }
+  });
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
- Fix #101 
- Add a new test for the created function `helper.validateActivity`
- Add created activities will now be validated through `validateActivity`
-`validateActivity` will validate all activities with the same rules

Rules for validation:
- All fields must have a value unequal undefined
- The `date` must be in the past but not older than 01.01.1990
- Field `shares`: Must be a number and greater than 0
- Field `price`: Must be a number and greater than 0
- Field `amount`: Must be a number and greater than 0
- Field `fee`: Must be a number and greater or equal than 0
- Field `tax`: Must be a number and greater or equal than 0
- The ISIN must have a valid format
- The type must be one of the following: Buy, Sell, Dividend

Fix invalid activities:
- Add missing tax fields for broker comdirect and DKB
- Rename broker postbank from `pb` to `postbank`